### PR TITLE
Improve accuracy of toLatLon

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -85,7 +85,7 @@ export function toLatLon(easting, northing, zoneNum, zoneLetter, northern, stric
   var n = R / epSinSqrt;
   var r = (1 - E) / epSin;
 
-  var c = _E * pCos * pCos;
+  var c = E_P2 * pCos * pCos;
   var c2 = c * c;
 
   var d = x / (n * K0);


### PR DESCRIPTION
The current implementation has inaccuracies.  See:
- https://github.com/Turbo87/utm/issues/36
- https://github.com/Turbo87/utm/pull/49

The current implementation is giving discrepancies around the 7th decimal place in degrees:

![image](https://user-images.githubusercontent.com/484870/107302737-f0776e00-6ad1-11eb-8331-670d8a9b2a84.png)
